### PR TITLE
Support for Create 6.0 in Version 1.20.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,13 @@
 **/build/
 !src/**/build/
 
+/*/run/
+/*/run/**
+/runs/
+/runs/**
+
+*.log
+
 # Ignore Gradle GUI config
 gradle-app.setting
 
@@ -19,3 +26,8 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# IntelliJ
+.idea/
+.idea/**
+

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'dev.architectury.loom' version '1.6-SNAPSHOT' apply false
+    id 'dev.architectury.loom' version '1.11-SNAPSHOT' apply false
     id 'architectury-plugin' version '3.4-SNAPSHOT'
     id 'com.github.johnrengelman.shadow' version '8.1.1' apply false
 }
@@ -82,6 +82,12 @@ subprojects {
         maven {
             name 'Gegy'
             url 'https://maven.gegy.dev'
+        }
+
+        repositories {
+            maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
+            maven { url = "https://maven.ithundxr.dev/mirror" } // Registrate
+            maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,15 +26,26 @@ subprojects {
     repositories {
         maven { url = "https://maven.parchmentmc.org" }
 
-        maven {
-            name = "Modrinth"
-            url = "https://api.modrinth.com/maven"
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    name = "Modrinth"
+                    url = "https://api.modrinth.com/maven"
+                }
+            }
+            filter {
                 includeGroup "maven.modrinth"
             }
         }
-        maven {
-            url "https://cursemaven.com"
+        exclusiveContent {
+            forRepository {
+                maven {
+                    url "https://cursemaven.com"
+                }
+            }
+            filter {
+                includeGroup "curse.maven"
+            }
         }
         maven {
             url "https://maven.tterrag.com/"
@@ -83,12 +94,10 @@ subprojects {
             name 'Gegy'
             url 'https://maven.gegy.dev'
         }
+        maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
+        maven { url = "https://maven.ithundxr.dev/mirror" } // Registrate
+        maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
 
-        repositories {
-            maven { url = "https://maven.createmod.net" } // Create, Ponder, Flywheel
-            maven { url = "https://maven.ithundxr.dev/mirror" } // Registrate
-            maven { url = "https://raw.githubusercontent.com/Fuzss/modresources/main/maven/" } // ForgeConfigAPIPort
-        }
     }
 
     loom {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
 //    modCompileOnly ("io.github.fabricators_of_create.Porting-Lib:entity:2.3.4+1.20.1")
 
-    modCompileOnly ("com.simibubi.create:create-fabric-${minecraft_version}:${create_fabric_version}")
+    modCompileOnly ("com.simibubi.create:create-fabric:${create_fabric_version}")
 
 //    modImplementation ("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim") { transitive = false }
 //    modImplementation ("maven.modrinth:lambdynamiclights:${lambdynamiclights_version}")

--- a/common/src/main/java/top/leonx/dynlight/CreateDynLight.java
+++ b/common/src/main/java/top/leonx/dynlight/CreateDynLight.java
@@ -25,7 +25,6 @@ public class CreateDynLight {
         LOGGER.info("Registering DynLightMovementBehaviours to REGISTRY");
         blocks.forEach(block -> {
             var lightEmission = block.defaultBlockState().getLightEmission();
-            // すでに登録済みでないか確認してから登録
             if (MovementBehaviour.REGISTRY.get(block) == null) {
                 MovementBehaviour.REGISTRY.register(block, new LightMovementBehaviour(lightEmission));
             }

--- a/common/src/main/java/top/leonx/dynlight/CreateDynLight.java
+++ b/common/src/main/java/top/leonx/dynlight/CreateDynLight.java
@@ -1,17 +1,20 @@
 package top.leonx.dynlight;
 
 import com.mojang.logging.LogUtils;
-import com.simibubi.create.AllMovementBehaviours;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.level.block.Block;
 import org.slf4j.Logger;
 
 import java.util.Collection;
 
-
 public class CreateDynLight {
     public static final String MOD_ID = "createdynlight";
     public static final Logger LOGGER = LogUtils.getLogger();
+
+    public static void init() {
+        registerGlobalBehaviourProvider();
+    }
 
     public static ResourceLocation asResource(String path) {
         return new ResourceLocation(MOD_ID, path);
@@ -19,17 +22,19 @@ public class CreateDynLight {
 
     @Deprecated
     public static void registerBehaviours(Collection<Block> blocks){
-        CreateDynLight.LOGGER.info("Registering DynLightMovementBehaviours");
+        LOGGER.info("Registering DynLightMovementBehaviours to REGISTRY");
         blocks.forEach(block -> {
             var lightEmission = block.defaultBlockState().getLightEmission();
-            AllMovementBehaviours.registerBehaviour(block, new LightMovementBehaviour(lightEmission));
+            // すでに登録済みでないか確認してから登録
+            if (MovementBehaviour.REGISTRY.get(block) == null) {
+                MovementBehaviour.REGISTRY.register(block, new LightMovementBehaviour(lightEmission));
+            }
         });
-        CreateDynLight.LOGGER.info("Registered LightMovementBehaviour for [{}]", String.join(", ", blocks.stream().map(Block::getDescriptionId).toList()));
     }
 
     public static void registerGlobalBehaviourProvider(){
         var provider = new LightBehaviourProvider();
-        AllMovementBehaviours.registerBehaviourProvider(provider);
-        CreateDynLight.LOGGER.info("Registered LightBehaviourProvider");
+        MovementBehaviour.REGISTRY.registerProvider(provider);
+        LOGGER.info("Registered LightBehaviourProvider to MovementBehaviour.REGISTRY");
     }
 }

--- a/common/src/main/java/top/leonx/dynlight/LightBehaviourProvider.java
+++ b/common/src/main/java/top/leonx/dynlight/LightBehaviourProvider.java
@@ -1,28 +1,29 @@
 package top.leonx.dynlight;
 
-import com.simibubi.create.AllMovementBehaviours;
-import com.simibubi.create.content.contraptions.behaviour.MovementBehaviour;
-import net.minecraft.world.level.block.state.BlockState;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
+import com.simibubi.create.api.registry.SimpleRegistry;
+import net.minecraft.world.level.block.Block;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 
-public class LightBehaviourProvider implements AllMovementBehaviours.BehaviourProvider {
+public class LightBehaviourProvider implements SimpleRegistry.Provider<Block, MovementBehaviour>
+{
 
-    List<LightMovementBehaviour> lightMovementBehaviours = new ArrayList<>(15);
-
-    public LightBehaviourProvider() {
-        for (int i = 0; i < 15; i++) {
-            lightMovementBehaviours.add(new LightMovementBehaviour(i + 1));
-        }
-    }
+    Map<Integer, LightMovementBehaviour> lightMovementBehaviours = new HashMap<>(15);
 
     @Override
-    public @Nullable MovementBehaviour getBehaviour(BlockState blockState) {
-        int lightEmission = blockState.getLightEmission();
+    public @Nullable MovementBehaviour get(Block block) {
+        int lightEmission = block.defaultBlockState().getLightEmission();
         if (lightEmission <= 0) return null;
-        var index = Math.min(15, lightEmission) - 1;
+        var index = Math.min(15, lightEmission);
         return lightMovementBehaviours.get(index);
+    }
+
+    public LightBehaviourProvider() {
+        for (int i = 1; i <= 15; i++) {
+            lightMovementBehaviours.put(i, new LightMovementBehaviour(i + 1));
+        }
     }
 }

--- a/common/src/main/java/top/leonx/dynlight/LightMovementBehaviour.java
+++ b/common/src/main/java/top/leonx/dynlight/LightMovementBehaviour.java
@@ -1,6 +1,6 @@
 package top.leonx.dynlight;
 
-import com.simibubi.create.content.contraptions.behaviour.MovementBehaviour;
+import com.simibubi.create.api.behaviour.movement.MovementBehaviour;
 import com.simibubi.create.content.contraptions.behaviour.MovementContext;
 import net.minecraft.core.BlockPos;
 import net.minecraft.nbt.NbtUtils;

--- a/common/src/main/java/top/leonx/dynlight/config/CreateDynLightClient.java
+++ b/common/src/main/java/top/leonx/dynlight/config/CreateDynLightClient.java
@@ -1,12 +1,13 @@
 package top.leonx.dynlight.config;
 
-import com.simibubi.create.foundation.config.ConfigBase;
+import net.createmod.catnip.config.ConfigBase;
+import org.jetbrains.annotations.NotNull;
 import top.leonx.dynlight.lamb.LambDynLightsDelegate;
 
 public class CreateDynLightClient extends ConfigBase {
 
     @Override
-    public String getName() {
+    public @NotNull String getName() {
         return "dynamic light client";
     }
 

--- a/common/src/main/java/top/leonx/dynlight/config/CreateDynLightCommon.java
+++ b/common/src/main/java/top/leonx/dynlight/config/CreateDynLightCommon.java
@@ -1,11 +1,12 @@
 package top.leonx.dynlight.config;
 
-import com.simibubi.create.foundation.config.ConfigBase;
+import net.createmod.catnip.config.ConfigBase;
+import org.jetbrains.annotations.NotNull;
 
 public class CreateDynLightCommon extends ConfigBase {
 
     @Override
-    public String getName() {
+    public @NotNull String getName() {
         return "dynamic light common";
     }
 

--- a/common/src/main/java/top/leonx/dynlight/config/CreateDynLightServer.java
+++ b/common/src/main/java/top/leonx/dynlight/config/CreateDynLightServer.java
@@ -1,11 +1,12 @@
 package top.leonx.dynlight.config;
 
-import com.simibubi.create.foundation.config.ConfigBase;
+import net.createmod.catnip.config.ConfigBase;
+import org.jetbrains.annotations.NotNull;
 
 public class CreateDynLightServer extends ConfigBase {
 
     @Override
-    public String getName() {
+    public @NotNull String getName() {
         return "dynamic light server";
     }
     public final ConfigBool enableLightBlock = b(false, "enableLightBlock", Comments.enableLightBlock);

--- a/common/src/main/java/top/leonx/dynlight/lamb/CreateDynLightSource.java
+++ b/common/src/main/java/top/leonx/dynlight/lamb/CreateDynLightSource.java
@@ -1,7 +1,6 @@
 package top.leonx.dynlight.lamb;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
-//import com.simibubi.create.foundation.utility.VecHelper;
 import net.createmod.catnip.math.VecHelper;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.client.Minecraft;
@@ -76,7 +75,7 @@ public abstract class CreateDynLightSource {
     }
 
 
-    public Level getDynamicLightWorld() {
+    public Level getDynamicLightLevel() {
         return contraptionEntity.level();
     }
 

--- a/common/src/main/java/top/leonx/dynlight/lamb/CreateDynLightSource.java
+++ b/common/src/main/java/top/leonx/dynlight/lamb/CreateDynLightSource.java
@@ -1,7 +1,8 @@
 package top.leonx.dynlight.lamb;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
-import com.simibubi.create.foundation.utility.VecHelper;
+//import com.simibubi.create.foundation.utility.VecHelper;
+import net.createmod.catnip.math.VecHelper;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.LevelRenderer;

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -33,17 +33,21 @@ dependencies {
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
 
-    modImplementation ("com.simibubi.create:create-fabric-${minecraft_version}:${create_fabric_version}")
+    modImplementation ("com.simibubi.create:create-fabric:${create_fabric_version}")
     modImplementation ("dev.lambdaurora:lambdynamiclights:${lambdynamiclights_version}")
+//    modImplementation "curse.maven:lambdynamiclights-393442:7010532"
+//    modImplementation "curse.maven:dynamiclights-reforged-551736:6044480"
     modCompileOnly("dev.lambdaurora:spruceui:${spruceui_version}")
     modImplementation ("com.terraformersmc:modmenu:${modmenu_version}")
     modImplementation ("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${forgeconfigapiport_fabric_version}")
 
     localRuntime ('org.anarres:jcpp:1.4.14')
     localRuntime ('io.github.douira:glsl-transformer:2.0.0-pre14')
-    modLocalRuntime ("maven.modrinth:sodium:mc1.20.1-0.5.11")
-    modLocalRuntime ("maven.modrinth:iris:1.7.2+1.20.1")
-    modLocalRuntime ("maven.modrinth:iris-flw-compat:fabric-1.20.1-1.1.0")
+    modLocalRuntime ("maven.modrinth:sodium:mc${minecraft_version}-${sodium_version}-fabric")
+    modLocalRuntime ("maven.modrinth:indium:${indium_version}+mc${minecraft_version}")
+    modLocalRuntime ("maven.modrinth:iris:${iris_version}+${minecraft_version}")
+    // Not compatible with Create 6
+//    modLocalRuntime ("maven.modrinth:iris-flw-compat:fabric-1.20.1-1.1.0")
 }
 
 processResources {
@@ -61,4 +65,17 @@ shadowJar {
 
 remapJar {
     input.set shadowJar.archiveFile
+}
+
+configurations.all {
+    // Sodium requires LWJGL 3.3.1
+    resolutionStrategy {
+        force 'org.lwjgl:lwjgl:3.3.1'
+        force 'org.lwjgl:lwjgl-jemalloc:3.3.1'
+        force 'org.lwjgl:lwjgl-openal:3.3.1'
+        force 'org.lwjgl:lwjgl-opengl:3.3.1'
+        force 'org.lwjgl:lwjgl-glfw:3.3.1'
+        force 'org.lwjgl:lwjgl-stb:3.3.1'
+        force 'org.lwjgl:lwjgl-tinyfd:3.3.1'
+    }
 }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -34,10 +34,7 @@ dependencies {
     shadowBundle project(path: ':common', configuration: 'transformProductionFabric')
 
     modImplementation ("com.simibubi.create:create-fabric:${create_fabric_version}")
-    modImplementation ("dev.lambdaurora:lambdynamiclights:${lambdynamiclights_version}")
-//    modImplementation "curse.maven:lambdynamiclights-393442:7010532"
-//    modImplementation "curse.maven:dynamiclights-reforged-551736:6044480"
-    modCompileOnly("dev.lambdaurora:spruceui:${spruceui_version}")
+    modImplementation ("maven.modrinth:sodium-dynamic-lights:${dynamiclights_fabric_version}")
     modImplementation ("com.terraformersmc:modmenu:${modmenu_version}")
     modImplementation ("fuzs.forgeconfigapiport:forgeconfigapiport-fabric:${forgeconfigapiport_fabric_version}")
 
@@ -46,8 +43,8 @@ dependencies {
     modLocalRuntime ("maven.modrinth:sodium:mc${minecraft_version}-${sodium_version}-fabric")
     modLocalRuntime ("maven.modrinth:indium:${indium_version}+mc${minecraft_version}")
     modLocalRuntime ("maven.modrinth:iris:${iris_version}+${minecraft_version}")
-    // Not compatible with Create 6
-//    modLocalRuntime ("maven.modrinth:iris-flw-compat:fabric-1.20.1-1.1.0")
+    // Flywheel and Iris compat
+    modLocalRuntime ("maven.modrinth:colorwheel:1.2.3+mc1.20.1")
 }
 
 processResources {

--- a/fabric/src/main/java/top/leonx/dynlight/config/fabric/CreateDynLightAllConfigsImpl.java
+++ b/fabric/src/main/java/top/leonx/dynlight/config/fabric/CreateDynLightAllConfigsImpl.java
@@ -1,6 +1,6 @@
 package top.leonx.dynlight.config.fabric;
 
-import com.simibubi.create.foundation.config.ConfigBase;
+import net.createmod.catnip.config.ConfigBase;
 import fuzs.forgeconfigapiport.api.config.v2.ForgeConfigRegistry;
 import fuzs.forgeconfigapiport.api.config.v2.ModConfigEvents;
 import net.minecraftforge.common.ForgeConfigSpec;

--- a/fabric/src/main/java/top/leonx/dynlight/fabric/CreateDynLightFabric.java
+++ b/fabric/src/main/java/top/leonx/dynlight/fabric/CreateDynLightFabric.java
@@ -8,6 +8,6 @@ public final class CreateDynLightFabric implements ModInitializer {
     @Override
     public void onInitialize() {
         CreateDynLightAllConfigsImpl.register();
-        CreateDynLight.registerGlobalBehaviourProvider();
+        CreateDynLight.init();
     }
 }

--- a/fabric/src/main/java/top/leonx/dynlight/fabric/client/CreateDynLightFabricClient.java
+++ b/fabric/src/main/java/top/leonx/dynlight/fabric/client/CreateDynLightFabricClient.java
@@ -7,8 +7,8 @@ import top.leonx.dynlight.fabric.LambModEventHandler;
 public final class CreateDynLightFabricClient implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
-        // If there is LambDynamicLights, register the event handler
-        if (FabricLoader.getInstance().isModLoaded("lambdynlights")) {
+        // If there is SodiumDynamicLights, register the event handler
+        if (FabricLoader.getInstance().isModLoaded("sodiumdynamiclights")) {
             LambModEventHandler.register();
         }
     }

--- a/fabric/src/main/java/top/leonx/dynlight/lamb/fabric/CreateDynLightSourceFabric.java
+++ b/fabric/src/main/java/top/leonx/dynlight/lamb/fabric/CreateDynLightSourceFabric.java
@@ -1,7 +1,7 @@
 package top.leonx.dynlight.lamb.fabric;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
-import dev.lambdaurora.lambdynlights.DynamicLightSource;
+import toni.sodiumdynamiclights.DynamicLightSource;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -14,52 +14,52 @@ public class CreateDynLightSourceFabric extends CreateDynLightSource implements 
     }
 
     @Override
-    public double getDynamicLightX() {
+    public double sdl$getDynamicLightX() {
         return super.getDynamicLightX();
     }
 
     @Override
-    public double getDynamicLightY() {
+    public double sdl$getDynamicLightY() {
         return super.getDynamicLightY();
     }
 
     @Override
-    public double getDynamicLightZ() {
+    public double sdl$getDynamicLightZ() {
         return super.getDynamicLightZ();
     }
 
     @Override
-    public Level getDynamicLightWorld() {
-        return super.getDynamicLightWorld();
+    public Level sdl$getDynamicLightLevel() {
+        return super.getDynamicLightLevel();
     }
 
     @Override
-    public void resetDynamicLight() {
+    public void sdl$resetDynamicLight() {
         super.resetDynamicLight();
     }
 
     @Override
-    public int getLuminance() {
+    public int sdl$getLuminance() {
         return super.getLuminance();
     }
 
     @Override
-    public void dynamicLightTick() {
+    public void sdl$dynamicLightTick() {
         super.dynamicLightTick();
     }
 
     @Override
-    public boolean shouldUpdateDynamicLight() {
+    public boolean sdl$shouldUpdateDynamicLight() {
         return super.shouldUpdateDynamicLight();
     }
 
     @Override
-    public boolean lambdynlights$updateDynamicLight(@NotNull LevelRenderer levelRenderer) {
+    public boolean sodiumdynamiclights$updateDynamicLight(@NotNull LevelRenderer levelRenderer) {
         return super.lambdynlights$updateDynamicLight(levelRenderer);
     }
 
     @Override
-    public void lambdynlights$scheduleTrackedChunksRebuild(@NotNull LevelRenderer levelRenderer) {
+    public void sodiumdynamiclights$scheduleTrackedChunksRebuild(@NotNull LevelRenderer levelRenderer) {
         super.lambdynlights$scheduleTrackedChunksRebuild(levelRenderer);
     }
 }

--- a/fabric/src/main/java/top/leonx/dynlight/lamb/fabric/LambDynLightsDelegateImpl.java
+++ b/fabric/src/main/java/top/leonx/dynlight/lamb/fabric/LambDynLightsDelegateImpl.java
@@ -1,7 +1,7 @@
 package top.leonx.dynlight.lamb.fabric;
 
-import dev.lambdaurora.lambdynlights.DynamicLightSource;
-import dev.lambdaurora.lambdynlights.LambDynLights;
+import toni.sodiumdynamiclights.DynamicLightSource;
+import toni.sodiumdynamiclights.SodiumDynamicLights;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
@@ -10,35 +10,35 @@ import top.leonx.dynlight.lamb.CreateDynLightSource;
 public class LambDynLightsDelegateImpl {
 
     public static void scheduleChunkRebuild(LevelRenderer levelRenderer, long pos){
-        LambDynLights.scheduleChunkRebuild(levelRenderer, pos);
+        SodiumDynamicLights.scheduleChunkRebuild(levelRenderer, pos);
     }
 
 
     public static void updateTrackedChunks(BlockPos.MutableBlockPos chunkPos, LongOpenHashSet lambdynlights$trackedLitChunkPos, LongOpenHashSet newPos) {
-        LambDynLights.updateTrackedChunks(chunkPos, lambdynlights$trackedLitChunkPos, newPos);
+        SodiumDynamicLights.updateTrackedChunks(chunkPos, lambdynlights$trackedLitChunkPos, newPos);
     }
 
     public static void scheduleChunkRebuild(LevelRenderer renderer, BlockPos.MutableBlockPos chunkPos) {
-        LambDynLights.scheduleChunkRebuild(renderer, chunkPos);
+        SodiumDynamicLights.scheduleChunkRebuild(renderer, chunkPos);
     }
 
     public static void addLightSource(CreateDynLightSource lightSource) {
         if (lightSource instanceof DynamicLightSource forgeLightSource) {
-            LambDynLights.get().addLightSource(forgeLightSource);
+            SodiumDynamicLights.get().addLightSource(forgeLightSource);
         }
     }
 
     public static void removeLightSource(CreateDynLightSource lightSource) {
         if (lightSource instanceof DynamicLightSource forgeLightSource) {
-            LambDynLights.get().removeLightSource(forgeLightSource);
+            SodiumDynamicLights.get().removeLightSource(forgeLightSource);
         }
     }
 
     public static boolean getDynamicLightsModeEnabled() {
-        return LambDynLights.get().config.getDynamicLightsMode().isEnabled();
+        return SodiumDynamicLights.get().config.getDynamicLightsMode().isEnabled();
     }
 
     public static int getDynamicLightsModeDelay(){
-        return LambDynLights.get().config.getDynamicLightsMode().getDelay();
+        return SodiumDynamicLights.get().config.getDynamicLightsMode().getDelay();
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -30,6 +30,6 @@
     "create": ">=6.0.0"
   },
   "suggests": {
-    "lambdynlights" : "*"
+    "sodiumdynamiclights" : ">=1.0.0"
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -27,7 +27,7 @@
     "minecraft": "~1.20.1",
     "java": ">=17",
     "fabric-api": "*",
-    "create": ">=0.5.0"
+    "create": ">=6.0.0"
   },
   "suggests": {
     "lambdynlights" : "*"

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -42,19 +42,18 @@ dependencies {
 
     common(project(path: ':common', configuration: 'namedElements')) { transitive false }
     shadowBundle project(path: ':common', configuration: 'transformProductionForge')
-    modImplementation ("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
-    modImplementation ("com.jozufozu.flywheel:flywheel-forge-${flywheel_minecraft_version}:${flywheel_forge_version}")
+    modImplementation ("com.simibubi.create:create-${minecraft_version}:${create_forge_version}:slim") { transitive = false }
+    modImplementation("net.createmod.ponder:Ponder-Forge-${minecraft_version}:${ponder_forge_version}")
+    modCompileOnly("dev.engine-room.flywheel:flywheel-forge-api-${minecraft_version}:${flywheel_forge_version}")
+    modRuntimeOnly("dev.engine-room.flywheel:flywheel-forge-${minecraft_version}:${flywheel_forge_version}")
     modImplementation ("com.tterrag.registrate:Registrate:${registrate_version}")
+    compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
+    implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
     modImplementation "curse.maven:dynamiclights-reforged-551736:${dynamiclights_curseforge_id}"
-
     forgeRuntimeLibrary ('org.anarres:jcpp:1.4.14')
-    modLocalRuntime ("org.embeddedt:embeddium-${minecraft_version}:${embeddium_version}+mc${minecraft_version}")
+    modLocalRuntime ("maven.modrinth:embeddium:${embeddium_version}+mc${minecraft_version}")
     modLocalRuntime ("maven.modrinth:oculus:${oculus_version}")
-    modLocalRuntime ("com.simibubi.create:create-${minecraft_version}:${create_version}:slim") { transitive = false }
-
-//    modLocalRuntime("maven.modrinth:create-contraption-terminals:1.20.1-1.0.0")
-//    modLocalRuntime("maven.modrinth:toms-storage:1.20-1.6.8")
-    //modLocalRuntime ("com.simibubi.create:create-${create_minecraft_version}:${create_version}:slim")
+    modLocalRuntime ("com.simibubi.create:create-${minecraft_version}:${create_forge_version}:slim") { transitive = false }
 }
 
 processResources {

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     modImplementation ("com.tterrag.registrate:Registrate:${registrate_version}")
     compileOnly(annotationProcessor("io.github.llamalad7:mixinextras-common:0.4.1"))
     implementation("io.github.llamalad7:mixinextras-forge:0.4.1")
-    modImplementation "curse.maven:dynamiclights-reforged-551736:${dynamiclights_curseforge_id}"
+    modImplementation ("maven.modrinth:sodium-dynamic-lights:${dynamiclights_forge_version}")
     forgeRuntimeLibrary ('org.anarres:jcpp:1.4.14')
     modLocalRuntime ("maven.modrinth:embeddium:${embeddium_version}+mc${minecraft_version}")
     modLocalRuntime ("maven.modrinth:oculus:${oculus_version}")

--- a/forge/src/main/java/top/leonx/dynlight/config/forge/CreateDynLightAllConfigsImpl.java
+++ b/forge/src/main/java/top/leonx/dynlight/config/forge/CreateDynLightAllConfigsImpl.java
@@ -1,6 +1,6 @@
 package top.leonx.dynlight.config.forge;
 
-import com.simibubi.create.foundation.config.ConfigBase;
+import net.createmod.catnip.config.ConfigBase;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.ModLoadingContext;

--- a/forge/src/main/java/top/leonx/dynlight/forge/CreateDynLightForge.java
+++ b/forge/src/main/java/top/leonx/dynlight/forge/CreateDynLightForge.java
@@ -32,7 +32,7 @@ public final class CreateDynLightForge {
     private void setup(FMLClientSetupEvent t) {
         CreateDynLight.LOGGER.info("CreateDynLight Initialized");
 
-        if (ModList.get().isLoaded("dynamiclightsreforged")) {
+        if (ModList.get().isLoaded("sodiumdynamiclights")) {
             t.enqueueWork(()->{
                 var forgeEventBus = MinecraftForge.EVENT_BUS;
                 forgeEventBus.addListener(LambModEventHandler::onEntityJoinWorld);
@@ -43,7 +43,7 @@ public final class CreateDynLightForge {
     }
 
     private void commonSetup(FMLCommonSetupEvent evt){
-        evt.enqueueWork(CreateDynLight::registerGlobalBehaviourProvider);
+        evt.enqueueWork(CreateDynLight::init);
     }
 
     private void modInit(FMLLoadCompleteEvent evt){

--- a/forge/src/main/java/top/leonx/dynlight/lamb/forge/CreateDynLightSourceForge.java
+++ b/forge/src/main/java/top/leonx/dynlight/lamb/forge/CreateDynLightSourceForge.java
@@ -1,7 +1,7 @@
 package top.leonx.dynlight.lamb.forge;
 
 import com.simibubi.create.content.contraptions.AbstractContraptionEntity;
-import dev.lambdaurora.lambdynlights.DynamicLightSource;
+import toni.sodiumdynamiclights.DynamicLightSource;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.Level;
@@ -14,52 +14,52 @@ public class CreateDynLightSourceForge extends CreateDynLightSource implements D
     }
 
     @Override
-    public double tdv$getDynamicLightX() {
+    public double sdl$getDynamicLightX() {
         return super.getDynamicLightX();
     }
 
     @Override
-    public double tdv$getDynamicLightY() {
+    public double sdl$getDynamicLightY() {
         return super.getDynamicLightY();
     }
 
     @Override
-    public double tdv$getDynamicLightZ() {
+    public double sdl$getDynamicLightZ() {
         return super.getDynamicLightZ();
     }
 
     @Override
-    public Level tdv$getDynamicLightWorld() {
-        return super.getDynamicLightWorld();
+    public Level sdl$getDynamicLightLevel() {
+        return getDynamicLightLevel();
     }
 
     @Override
-    public void tdv$resetDynamicLight() {
+    public void sdl$resetDynamicLight() {
         super.resetDynamicLight();
     }
 
     @Override
-    public int tdv$getLuminance() {
+    public int sdl$getLuminance() {
         return super.getLuminance();
     }
 
     @Override
-    public void tdv$dynamicLightTick() {
+    public void sdl$dynamicLightTick() {
         super.dynamicLightTick();
     }
 
     @Override
-    public boolean tdv$shouldUpdateDynamicLight() {
+    public boolean sdl$shouldUpdateDynamicLight() {
         return super.shouldUpdateDynamicLight();
     }
 
     @Override
-    public boolean tdv$lambdynlights$updateDynamicLight(@NotNull LevelRenderer levelRenderer) {
-        return super.lambdynlights$updateDynamicLight(levelRenderer);
+    public boolean sodiumdynamiclights$updateDynamicLight(@NotNull LevelRenderer levelRenderer) {
+        return lambdynlights$updateDynamicLight(levelRenderer);
     }
 
     @Override
-    public void tdv$lambdynlights$scheduleTrackedChunksRebuild(@NotNull LevelRenderer levelRenderer) {
-        super.lambdynlights$scheduleTrackedChunksRebuild(levelRenderer);
+    public void sodiumdynamiclights$scheduleTrackedChunksRebuild(@NotNull LevelRenderer levelRenderer) {
+        lambdynlights$scheduleTrackedChunksRebuild(levelRenderer);
     }
 }

--- a/forge/src/main/java/top/leonx/dynlight/lamb/forge/LambDynLightsDelegateImpl.java
+++ b/forge/src/main/java/top/leonx/dynlight/lamb/forge/LambDynLightsDelegateImpl.java
@@ -1,9 +1,9 @@
 package top.leonx.dynlight.lamb.forge;
 
-import dev.lambdaurora.lambdynlights.DynamicLightSource;
-import dev.lambdaurora.lambdynlights.LambDynLights;
-import dev.lambdaurora.lambdynlights.config.DynamicLightsConfig;
-import dev.lambdaurora.lambdynlights.config.QualityMode;
+import toni.sodiumdynamiclights.DynamicLightSource;
+import toni.sodiumdynamiclights.SodiumDynamicLights;
+import toni.sodiumdynamiclights.DynamicLightsConfig;
+import toni.sodiumdynamiclights.DynamicLightsMode;
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import net.minecraft.client.renderer.LevelRenderer;
 import net.minecraft.core.BlockPos;
@@ -14,40 +14,40 @@ import java.util.Objects;
 public class LambDynLightsDelegateImpl {
 
     public static void scheduleChunkRebuild(LevelRenderer levelRenderer, long pos){
-        LambDynLights.scheduleChunkRebuild(levelRenderer, pos);
+        SodiumDynamicLights.scheduleChunkRebuild(levelRenderer, pos);
     }
 
 
     public static void updateTrackedChunks(BlockPos.MutableBlockPos chunkPos, LongOpenHashSet lambdynlights$trackedLitChunkPos, LongOpenHashSet newPos) {
-        LambDynLights.updateTrackedChunks(chunkPos, lambdynlights$trackedLitChunkPos, newPos);
+        SodiumDynamicLights.updateTrackedChunks(chunkPos, lambdynlights$trackedLitChunkPos, newPos);
     }
 
     public static void scheduleChunkRebuild(LevelRenderer renderer, BlockPos.MutableBlockPos chunkPos) {
-        LambDynLights.scheduleChunkRebuild(renderer, chunkPos);
+        SodiumDynamicLights.scheduleChunkRebuild(renderer, chunkPos);
     }
 
     public static void addLightSource(CreateDynLightSource lightSource) {
         if (lightSource instanceof DynamicLightSource forgeLightSource) {
-            LambDynLights.get().addLightSource(forgeLightSource);
+            SodiumDynamicLights.get().addLightSource(forgeLightSource);
         }
     }
 
     public static void removeLightSource(CreateDynLightSource lightSource) {
         if (lightSource instanceof DynamicLightSource forgeLightSource) {
-            LambDynLights.get().removeLightSource(forgeLightSource);
+            SodiumDynamicLights.get().removeLightSource(forgeLightSource);
         }
     }
 
     public static boolean getDynamicLightsModeEnabled() {
-        QualityMode mode = DynamicLightsConfig.Quality.get();
-        return !Objects.equals(mode, QualityMode.OFF);
+        DynamicLightsMode mode = DynamicLightsConfig.DYNAMIC_LIGHTS_MODE.get();
+        return !Objects.equals(mode, DynamicLightsMode.OFF);
     }
 
     public static int getDynamicLightsModeDelay(){
-        QualityMode mode = DynamicLightsConfig.Quality.get();
-        if (Objects.equals(mode, QualityMode.SLOW)) {
+        DynamicLightsMode mode = DynamicLightsConfig.DYNAMIC_LIGHTS_MODE.get();
+        if (Objects.equals(mode, DynamicLightsMode.SLOW)) {
             return 500;
-        } else if (Objects.equals(mode, QualityMode.FAST)) {
+        } else if (Objects.equals(mode, DynamicLightsMode.FAST)) {
             return 200;
         } else {
             return 0;

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -34,8 +34,8 @@ displayTest="IGNORE_ALL_VERSION"
     side="BOTH"
 
 [[dependencies.createdynlight]]
-    modId="dynamiclightsreforged"
+    modId="sodiumdynamiclights"
     mandatory=false
-    versionRange="[1.6.0,)"
+    versionRange="[1.0.0,1.1.0)"
     ordering="AFTER"
     side="CLIENT"

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -29,7 +29,7 @@ displayTest="IGNORE_ALL_VERSION"
 [[dependencies.createdynlight]]
     modId="create"
     mandatory=true
-    versionRange="[0.5.0,)"
+    versionRange="[6.0.0,6.1.0)"
     ordering="AFTER"
     side="BOTH"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,23 +18,21 @@ fabric_loader_version = 0.16.0
 fabric_api_version = 0.92.2+1.20.1
 forge_version = 1.20.1-47.3.3
 
-dynamiclights_curseforge_id = 4731947
-
-# Forge
+# Forge dependencies
 create_forge_version = 6.0.8-289
 ponder_forge_version = 1.0.91
 flywheel_forge_version = 1.0.5
 registrate_version = MC1.20-1.3.3
 embeddium_version = 0.3.30
 oculus_version = 1.20.1-1.8.0
+dynamiclights_forge_version = forge-1.20.1-1.0.10
 
-# Fabric
+# Fabric dependencies
 create_fabric_version = 6.0.8.1+build.1744-mc1.20.1
 flywheel_fabric_version = 1.0.5
 sodium_version = 0.5.13
-lambdynamiclights_version = 2.3.2+1.20.1-local
+dynamiclights_fabric_version = fabric-1.20.1-1.0.10
 indium_version = 1.0.36
 iris_version = 1.7.6
 modmenu_version = 7.2.2
 forgeconfigapiport_fabric_version = 8.0.0
-spruceui_version = 5.0.0+1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
 # Done to increase the memory available to Gradle.
-org.gradle.jvmargs=-Xmx2G
+org.gradle.jvmargs=-Xmx2G -Dfile.encoding=UTF-8
 org.gradle.parallel=true
 
+
 # Mod properties
-mod_version = 1.0.1
+mod_version = 1.1.0
 maven_group = top.leonx.dynlight
 archives_name = create-dyn-light
 enabled_platforms = fabric,forge
@@ -17,24 +18,23 @@ fabric_loader_version = 0.16.0
 fabric_api_version = 0.92.2+1.20.1
 forge_version = 1.20.1-47.3.3
 
-create_minecraft_version = 1.20.1
-create_version = 0.5.1.e-22
-create_fabric_version = 0.5.1-f-build.1417+mc1.20.1
-lambdynamiclights_version = 2.3.2+1.20.1-local
-
-
-flywheel_minecraft_version = 1.20.1
-flywheel_fabric_version = 0.6.10-2
-flywheel_forge_version = 0.6.10-7
-sodium_version = mc1.20.1-0.5.8
-embeddium_version = 0.3.9-git.f603a93
-iris_version = 1.7.0+1.20.1
-oculus_version = 1.20.1-1.7.0
-lithium_version = mc1.20.1-0.11.2
-registrate_version = MC1.20-1.3.3
-
 dynamiclights_curseforge_id = 4731947
 
+# Forge
+create_forge_version = 6.0.8-289
+ponder_forge_version = 1.0.91
+flywheel_forge_version = 1.0.5
+registrate_version = MC1.20-1.3.3
+embeddium_version = 0.3.30
+oculus_version = 1.20.1-1.8.0
+
+# Fabric
+create_fabric_version = 6.0.8.1+build.1744-mc1.20.1
+flywheel_fabric_version = 1.0.5
+sodium_version = 0.5.13
+lambdynamiclights_version = 2.3.2+1.20.1-local
+indium_version = 1.0.36
+iris_version = 1.7.6
 modmenu_version = 7.2.2
 forgeconfigapiport_fabric_version = 8.0.0
 spruceui_version = 5.0.0+1.20

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.parallel=true
 
 
 # Mod properties
-mod_version = 1.1.0
+mod_version = 2.0.0
 maven_group = top.leonx.dynlight
 archives_name = create-dyn-light
 enabled_platforms = fabric,forge

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Description
This PR introduces compatibility with Create 6.0 and fully migrates the dynamic lighting dependency to SodiumDynamicLights. This serves as a major update (v2.0.0) for the mod.

## Changes Made

### 1. Create 6.0 Compatibility (Catnip Migration)
Adapted to the extensive API refactoring introduced in Create 6.0.
- Migrated `LightBehaviourProvider` from the deprecated `AllMovementBehaviours.BehaviourProvider` to the new `SimpleRegistry.Provider<Block, MovementBehaviour>` API.
- Updated imports for utilities like `ConfigBase` and `VecHelper` from `com.simibubi.create.foundation.*` to `net.createmod.catnip.*`, reflecting Create's library split.
- Bumped the required Create version to `>= 6.0.0` in `fabric.mod.json` and `mods.toml`.

### 2. Migration to SodiumDynamicLights
Exclusively migrated dynamic lighting support to SodiumDynamicLights.
- **Removed** all legacy support and compatibility code for LambDynamicLights and DynamicLightsReforged.
- Implemented specific hooks and initialization checks for `sodiumdynamiclights`, ensuring dynamic lighting works properly with SodiumDynamicLights version 1.0.10 and newer.

### 3. Bug Fixes
- **Fix #6:** Resolved a crash in `CreateDynLightSourceHolder.removeAll` that occurred when a ContraptionEntity lacked its contraption data.

## Testing
- [x] Verified successful builds on both Fabric and Forge with Create 6.0.
- [x] Tested in-game with SodiumDynamicLights 1.0.10+ to ensure contraptions emit dynamic light properly.
